### PR TITLE
non-preallocated metric terms

### DIFF
--- a/src/Canary.jl
+++ b/src/Canary.jl
@@ -10,6 +10,8 @@ __precompile__(false)
 export brickmesh, centroidtocode, partition, connectmesh, mappings
 export lglpoints, lgpoints
 export barycentricweights, spectralderivative, interpolationmatrix
+export creategrid!, computemetric!
+export creategrid2d, creategrid3d, computemetric
 
 include("mesh.jl")
 include("operators.jl")

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -362,9 +362,12 @@ function computemetric!(x::AbstractArray{T, 4},
   (J, rx, sx, tx, ry, sy, ty, rz, sz, tz, sJ, nx, ny, nz)
 end
 
+creategrid2d(elemtocoord, r) = creategrid(Val(2), elemtocoord, r)
+creategrid3d(elemtocoord, r) = creategrid(Val(3), elemtocoord, r)
+
 """
-    creategrid2d(elemtocoord::AbstractArray{S, 3},
-                 r::AbstractVector{T}) where {S, T}
+    creategrid(::Val{2}, elemtocoord::AbstractArray{S, 3},
+               r::AbstractVector{T}) where {S, T}
 
 Create a 2-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
 using the 1-D `(-1, 1)` reference coordinates `r`. The element grids are filled
@@ -372,8 +375,8 @@ using bilinear interpolation of the element coordinates.
 
 The grid is returned as a tuple of the `x` and `y` arrays
 """
-function creategrid2d(e2c::AbstractArray{S, 3},
-                     r::AbstractVector{T}) where {S, T}
+function creategrid(::Val{2}, e2c::AbstractArray{S, 3},
+                    r::AbstractVector{T}) where {S, T}
   (d, nvert, nelem) = size(e2c)
   @assert d == 2
   Nq = length(r)
@@ -384,8 +387,8 @@ function creategrid2d(e2c::AbstractArray{S, 3},
 end
 
 """
-    creategrid3d(elemtocoord::AbstractArray{S, 3},
-                 r::AbstractVector{T}) where {S, T}
+    creategrid(::Val{3}, elemtocoord::AbstractArray{S, 3},
+               r::AbstractVector{T}) where {S, T}
 
 Create a 3-D tensor product grid using `elemtocoord` (see [`brickmesh`](@ref))
 using the 1-D `(-1, 1)` reference coordinates `r`. The element grids are filled
@@ -393,8 +396,8 @@ using bilinear interpolation of the element coordinates.
 
 The grid is returned as a tuple of the `x`, `y`, `z` arrays
 """
-function creategrid3d(e2c::AbstractArray{S, 3},
-                     r::AbstractVector{T}) where {S, T}
+function creategrid(::Val{3}, e2c::AbstractArray{S, 3},
+                    r::AbstractVector{T}) where {S, T}
   (d, nvert, nelem) = size(e2c)
   @assert d == 3
   Nq = length(r)

--- a/test/test_metric.jl
+++ b/test/test_metric.jl
@@ -104,7 +104,6 @@ const SGEO3D = (sJ = 1, nx = 2, ny = 3, nz = 4)
     #{{{
     let
       N = 4
-      T = Float64
 
       f(r,s) = (9 .* r - (1 .+ r) .* s.^2 + (r .- 1).^2 .* (1 .- s.^2 .+ s.^3),
                 10 .* s .+ r.^4 .* (1 .- s) .+ r.^2 .* s .* (1 .+ s))
@@ -143,7 +142,7 @@ const SGEO3D = (sJ = 1, nx = 2, ny = 3, nz = 4)
       @test (@view vgeo[:, :, VGEO2D.ry, :]) ≈ -xs ./ J
       @test (@view vgeo[:, :, VGEO2D.sy, :]) ≈  xr ./ J
 
-      # TODO: check the normals?
+      # check the normals?
       nx = @view sgeo[:,:,SGEO2D.nx,:]
       ny = @view sgeo[:,:,SGEO2D.ny,:]
       sJ = @view sgeo[:,:,SGEO2D.sJ,:]
@@ -157,10 +156,60 @@ const SGEO3D = (sJ = 1, nx = 2, ny = 3, nz = 4)
       @test sJ[:,4,:] .* nx[:,4,:] ≈ -yr[:,Nq,:]
       @test sJ[:,4,:] .* ny[:,4,:] ≈  xr[:,Nq,:]
     end
-  end
-  #}}}
+    #}}}
 
-  # Constant preserving test?
+    #{{{
+    let
+      N = 4
+
+      f(r,s) = (9 .* r - (1 .+ r) .* s.^2 + (r .- 1).^2 .* (1 .- s.^2 .+ s.^3),
+                10 .* s .+ r.^4 .* (1 .- s) .+ r.^2 .* s .* (1 .+ s))
+      fxr(r,s) = 7 .+ s.^2 .- 2 .* s.^3 .+ 2 .* r .* (1 .- s.^2 .+ s.^3)
+      fxs(r,s) = -2 .* (1 .+ r) .* s .+ (-1 .+ r).^2 .* s .* (-2 .+ 3 .* s)
+      fyr(r,s) = -4 .* r.^3 .* (-1 .+ s) .+ 2 .* r .* s .* (1 .+ s)
+      fys(r,s) = 10 .- r.^4 .+ r.^2 .* (1 .+ 2 .* s)
+
+      r, w = Canary.lglpoints(T, N)
+      D = Canary.spectralderivative(r)
+      Nq = N + 1
+
+      d = 2
+      nfaces = 4
+      e2c = Array{T, 3}(undef, 2, 4, 1)
+      e2c[:, :, 1] = [-1 1 -1 1;-1 -1 1 1]
+      nelem = size(e2c, 3)
+
+      (x, y) = Canary.creategrid2d(e2c, r)
+
+      (xr, xs, yr, ys) = (fxr(x, y), fxs(x,y), fyr(x,y), fys(x,y))
+      J = xr .* ys - xs .* yr
+      foreach(j->(x[j], y[j]) = f(x[j], y[j]), 1:length(x))
+
+      metric = Canary.computemetric(x, y, D)
+      @test J ≈ metric.J
+      @test metric.rx ≈  ys ./ J
+      @test metric.sx ≈ -yr ./ J
+      @test metric.ry ≈ -xs ./ J
+      @test metric.sy ≈  xr ./ J
+
+      # check the normals?
+      nx = metric.nx
+      ny = metric.ny
+      sJ = metric.sJ
+      @test hypot.(nx, ny) ≈ ones(T, size(nx))
+      @test sJ[:,1,:] .* nx[:,1,:] ≈ -ys[ 1,:,:]
+      @test sJ[:,1,:] .* ny[:,1,:] ≈  xs[ 1,:,:]
+      @test sJ[:,2,:] .* nx[:,2,:] ≈  ys[Nq,:,:]
+      @test sJ[:,2,:] .* ny[:,2,:] ≈ -xs[Nq,:,:]
+      @test sJ[:,3,:] .* nx[:,3,:] ≈  yr[:, 1,:]
+      @test sJ[:,3,:] .* ny[:,3,:] ≈ -xr[:, 1,:]
+      @test sJ[:,4,:] .* nx[:,4,:] ≈ -yr[:,Nq,:]
+      @test sJ[:,4,:] .* ny[:,4,:] ≈  xr[:,Nq,:]
+    end
+    #}}}
+  end
+
+  # Constant preserving test
   #{{{
   let
     N = 4
@@ -552,6 +601,105 @@ end
     end
   end
   #}}}
+
+  #{{{
+  for T ∈ (Float32, Float64, BigFloat)
+    f(r, s, t) = @.( (s + r*t - (r^2*s^2*t^2)/4,
+                      t - ((r*s*t)/2 + 1/2)^3 + 1,
+                      r + (r/2 + 1/2)^6*(s/2 + 1/2)^6*(t/2 + 1/2)^6))
+
+    fxr(r, s, t) = @.(t - (r*s^2*t^2)/2)
+    fxs(r, s, t) = @.(1 - (r^2*s*t^2)/2)
+    fxt(r, s, t) = @.(r - (r^2*s^2*t)/2)
+    fyr(r, s, t) = @.(-(3*s*t*((r*s*t)/2 + 1/2)^2)/2)
+    fys(r, s, t) = @.(-(3*r*t*((r*s*t)/2 + 1/2)^2)/2)
+    fyt(r, s, t) = @.(1 - (3*r*s*((r*s*t)/2 + 1/2)^2)/2)
+    fzr(r, s, t) = @.(3*(r/2 + 1/2)^5*(s/2 + 1/2)^6*(t/2 + 1/2)^6 + 1)
+    fzs(r, s, t) = @.(3*(r/2 + 1/2)^6*(s/2 + 1/2)^5*(t/2 + 1/2)^6)
+    fzt(r, s, t) = @.(3*(r/2 + 1/2)^6*(s/2 + 1/2)^6*(t/2 + 1/2)^5)
+
+    let
+      N = 9
+
+      r, w = Canary.lglpoints(T, N)
+      D = Canary.spectralderivative(r)
+      Nq = N + 1
+
+      d = 3
+      nfaces = 6
+      e2c = Array{T, 3}(undef, d, 8, 1)
+      e2c[:, :, 1] = [-1  1 -1  1 -1  1 -1  1;
+                      -1 -1  1  1 -1 -1  1  1;
+                      -1 -1 -1 -1  1  1  1  1]
+
+      nelem = size(e2c, 3)
+
+      vgeo = Array{T, 5}(undef, Nq, Nq, Nq, length(VGEO3D), nelem)
+      sgeo = Array{T, 5}(undef, Nq, Nq, nfaces, length(SGEO3D), nelem)
+      (x,y,z) = creategrid3d(e2c, r)
+
+      (xr, xs, xt,
+       yr, ys, yt,
+       zr, zs, zt) = (fxr(x,y,z), fxs(x,y,z), fxt(x,y,z),
+                      fyr(x,y,z), fys(x,y,z), fyt(x,y,z),
+                      fzr(x,y,z), fzs(x,y,z), fzt(x,y,z))
+      J = (xr .* (ys .* zt - yt .* zs) +
+           yr .* (zs .* xt - zt .* xs) +
+           zr .* (xs .* yt - xt .* ys))
+
+      rx =  (ys .* zt - yt .* zs) ./ J
+      ry =  (zs .* xt - zt .* xs) ./ J
+      rz =  (xs .* yt - xt .* ys) ./ J
+      sx =  (yt .* zr - yr .* zt) ./ J
+      sy =  (zt .* xr - zr .* xt) ./ J
+      sz =  (xt .* yr - xr .* yt) ./ J
+      tx =  (yr .* zs - ys .* zr) ./ J
+      ty =  (zr .* xs - zs .* xr) ./ J
+      tz =  (xr .* ys - xs .* yr) ./ J
+
+      foreach(j->(x[j], y[j], z[j]) = f(x[j], y[j], z[j]), 1:length(x))
+
+      metric = computemetric(x, y, z, D)
+
+      @test metric.J ≈ J
+      @test metric.rx ≈ rx
+      @test metric.ry ≈ ry
+      @test metric.rz ≈ rz
+      @test metric.sx ≈ sx
+      @test metric.sy ≈ sy
+      @test metric.sz ≈ sz
+      @test metric.tx ≈ tx
+      @test metric.ty ≈ ty
+      @test metric.tz ≈ tz
+      nx = metric.nx
+      ny = metric.ny
+      nz = metric.nz
+      sJ = metric.sJ
+      @test hypot.(nx, ny, nz) ≈ ones(T, size(nx))
+      @test ([sJ[:,:,1,:] .* nx[:,:,1,:], sJ[:,:,1,:] .* ny[:,:,1,:],
+              sJ[:,:,1,:] .* nz[:,:,1,:]] ≈
+             [-J[ 1,:,:,:] .* rx[ 1,:,:,:], -J[ 1,:,:,:] .* ry[ 1,:,:,:],
+              -J[ 1,:,:,:] .* rz[ 1,:,:,:]])
+      @test ([sJ[:,:,2,:] .* nx[:,:,2,:], sJ[:,:,2,:] .* ny[:,:,2,:],
+              sJ[:,:,2,:] .* nz[:,:,2,:]] ≈
+             [ J[Nq,:,:,:] .* rx[Nq,:,:,:],  J[Nq,:,:,:] .* ry[Nq,:,:,:],
+               J[Nq,:,:,:] .* rz[Nq,:,:,:]])
+      @test sJ[:,:,3,:] .* nx[:,:,3,:] ≈ -J[:, 1,:,:] .* sx[:, 1,:,:]
+      @test sJ[:,:,3,:] .* ny[:,:,3,:] ≈ -J[:, 1,:,:] .* sy[:, 1,:,:]
+      @test sJ[:,:,3,:] .* nz[:,:,3,:] ≈ -J[:, 1,:,:] .* sz[:, 1,:,:]
+      @test sJ[:,:,4,:] .* nx[:,:,4,:] ≈  J[:,Nq,:,:] .* sx[:,Nq,:,:]
+      @test sJ[:,:,4,:] .* ny[:,:,4,:] ≈  J[:,Nq,:,:] .* sy[:,Nq,:,:]
+      @test sJ[:,:,4,:] .* nz[:,:,4,:] ≈  J[:,Nq,:,:] .* sz[:,Nq,:,:]
+      @test sJ[:,:,5,:] .* nx[:,:,5,:] ≈ -J[:,:, 1,:] .* tx[:,:, 1,:]
+      @test sJ[:,:,5,:] .* ny[:,:,5,:] ≈ -J[:,:, 1,:] .* ty[:,:, 1,:]
+      @test sJ[:,:,5,:] .* nz[:,:,5,:] ≈ -J[:,:, 1,:] .* tz[:,:, 1,:]
+      @test sJ[:,:,6,:] .* nx[:,:,6,:] ≈  J[:,:,Nq,:] .* tx[:,:,Nq,:]
+      @test sJ[:,:,6,:] .* ny[:,:,6,:] ≈  J[:,:,Nq,:] .* ty[:,:,Nq,:]
+      @test sJ[:,:,6,:] .* nz[:,:,6,:] ≈  J[:,:,Nq,:] .* tz[:,:,Nq,:]
+    end
+  end
+  #}}}
+
 
   # Constant preserving test
   #{{{


### PR DESCRIPTION
Adding functions to `metrics.jl` so that the user does not have to preallocate the arrays.