### PR TITLE
Update surface metric storage and variable names

### DIFF
--- a/examples/advection.jl
+++ b/examples/advection.jl
@@ -125,7 +125,7 @@ dt = [floatmax(DFloat)]
 if dim == 1
 
 elseif dim == 2
-  (ξx, ξy, ηx, ηy) = (metric.rx, metric.ry, metric.sx, metric.sy)
+  (ξx, ξy, ηx, ηy) = (metric.ξx, metric.ξy, metric.ηx, metric.ηy)
   (Ux, Uy) = (Q.Ux, Q.Uy)
   for n = 1:length(Ux)
     loc_dt = 2 ./ max(abs.(Ux[n] * ξx[n] + Uy[n] * ξy[n]),
@@ -133,9 +133,9 @@ elseif dim == 2
     dt[1] = min(dt[1], loc_dt)
   end
 elseif dim == 3
-  (ξx, ξy, ξz) = (metric.rx, metric.ry, metric.rz)
-  (ηx, ηy, ηz) = (metric.sx, metric.sy, metric.sz)
-  (ζx, ζy, ζz) = (metric.tx, metric.ty, metric.tz)
+  (ξx, ξy, ξz) = (metric.ξx, metric.ξy, metric.ξz)
+  (ηx, ηy, ηz) = (metric.ηx, metric.ηy, metric.ηz)
+  (ζx, ζy, ζz) = (metric.ζx, metric.ζy, metric.ζz)
   (Ux, Uy, Uz) = (Q.Ux, Q.Uy, Q.Uz)
   for n = 1:length(Ux)
     loc_dt = 2 ./ max(abs.(Ux[n] * ξx[n] + Uy[n] * ξy[n] + Uz[n] * ξz[n]),
@@ -207,7 +207,7 @@ function volumerhs!(rhs, Q::NamedTuple{S, NTuple{3, T}}, metric, D, ω,
   (ρ, Ux, Uy) = (Q.ρ, Q.Ux, Q.Uy)
   Nq = size(ρ, 1)
   J = metric.J
-  (ξx, ηx, ξy, ηy) = (metric.rx, metric.sx, metric.ry, metric.sy)
+  (ξx, ηx, ξy, ηy) = (metric.ξx, metric.ηx, metric.ξy, metric.ηy)
   # for each element
   for e ∈ elems
     # loop of ξ-grid lines
@@ -232,9 +232,9 @@ function volumerhs!(rhs, Q::NamedTuple{S, NTuple{4, T}}, metric, D, ω,
   (ρ, Ux, Uy, Uz) = (Q.ρ, Q.Ux, Q.Uy, Q.Uz)
   Nq = size(ρ, 1)
   J = metric.J
-  (ξx, ηx, ζx) = (metric.rx, metric.sx, metric.tx)
-  (ξy, ηy, ζy) = (metric.ry, metric.sy, metric.ty)
-  (ξz, ηz, ζz) = (metric.rz, metric.sz, metric.tz)
+  (ξx, ηx, ζx) = (metric.ξx, metric.ηx, metric.ζx)
+  (ξy, ηy, ζy) = (metric.ξy, metric.ηy, metric.ζy)
+  (ξz, ηz, ζz) = (metric.ξz, metric.ηz, metric.ζz)
   for e ∈ elems
     # loop of ξ-grid lines
     for k = 1:Nq
@@ -307,10 +307,6 @@ function facerhs!(rhs, Q::NamedTuple{S, NTuple{4, T}}, metric, ω, elems, vmapM,
   (ρ, Ux, Uy, Uz) = (Q.ρ, Q.Ux, Q.Uy, Q.Uz)
   nface = 6
   (nx, ny, nz, sJ) = (metric.nx, metric.ny, metric.nz, metric.sJ)
-  nx = reshape(nx, size(vmapM))
-  ny = reshape(ny, size(vmapM))
-  nz = reshape(nz, size(vmapM))
-  sJ = reshape(sJ, size(vmapM))
   for e ∈ elems
     for f ∈ 1:nface
       ρM = ρ[vmapM[:, f, e]]

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -113,7 +113,7 @@ end
 """
     computemetric!(x::AbstractArray{T, 2},
                    J::AbstractArray{T, 2},
-                   rx::AbstractArray{T, 2},
+                   ξx::AbstractArray{T, 2},
                    sJ::AbstractArray{T, 3},
                    nx::AbstractArray{T, 3},
                    D::AbstractMatrix{T}) where T
@@ -123,12 +123,12 @@ are preallocated by the user and the (square) derivative matrix `D` should be
 consistent with the reference grid `r` used in [`creategrid!`](@ref).
 
 If `Nq = size(D, 1)` and `nelem = size(x, 2)` then the volume arrays `x`, `J`,
-and `rx` should all be of size `(Nq, nelem)`.  Similarly, the face arrays `sJ`
+and `ξx` should all be of size `(Nq, nelem)`.  Similarly, the face arrays `sJ`
 and `nx` should be of size `(1, nfaces, nelem)` with `nfaces = 2`.
 """
 function computemetric!(x::AbstractArray{T, 2},
                         J::AbstractArray{T, 2},
-                        rx::AbstractArray{T, 2},
+                        ξx::AbstractArray{T, 2},
                         sJ::AbstractArray{T, 3},
                         nx::AbstractArray{T, 3},
                         D::AbstractMatrix{T}) where T
@@ -139,19 +139,19 @@ function computemetric!(x::AbstractArray{T, 2},
   for e = 1:nelem
     J[:, e] = D * x[:, e]
   end
-  rx .=  1 ./ J
+  ξx .=  1 ./ J
 
   nx[1, 1, :] .= -sign.(J[ 1, :])
   nx[1, 2, :] .=  sign.(J[Nq, :])
   sJ .= 1
-  (J, rx, sJ, nx)
+  (J, ξx, sJ, nx)
 end
 
 """
     computemetric!(x::AbstractArray{T, 3}, y::AbstractArray{T, 3},
                    J::AbstractArray{T, 3},
-                   rx::AbstractArray{T, 3}, sx::AbstractArray{T, 3},
-                   ry::AbstractArray{T, 3}, sy::AbstractArray{T, 3},
+                   ξx::AbstractArray{T, 3}, ηx::AbstractArray{T, 3},
+                   ξy::AbstractArray{T, 3}, ηy::AbstractArray{T, 3},
                    sJ::AbstractArray{T, 3},
                    nx::AbstractArray{T, 3}, ny::AbstractArray{T, 3},
                    D::AbstractMatrix{T}) where T
@@ -161,14 +161,14 @@ arrays are preallocated by the user and the (square) derivative matrix `D`
 should be consistent with the reference grid `r` used in [`creategrid!`](@ref).
 
 If `Nq = size(D, 1)` and `nelem = size(x, 3)` then the volume arrays `x`, `y`,
-`J`, `rx`, `sx`, `ry`, and `sy` should all be of size `(Nq, Nq, nelem)`.
+`J`, `ξx`, `ηx`, `ξy`, and `ηy` should all be of size `(Nq, Nq, nelem)`.
 Similarly, the face arrays `sJ`, `nx`, and `ny` should be of size `(Nq, nfaces,
 nelem)` with `nfaces = 4`.
 """
 function computemetric!(x::AbstractArray{T, 3}, y::AbstractArray{T, 3},
                         J::AbstractArray{T, 3},
-                        rx::AbstractArray{T, 3}, sx::AbstractArray{T, 3},
-                        ry::AbstractArray{T, 3}, sy::AbstractArray{T, 3},
+                        ξx::AbstractArray{T, 3}, ηx::AbstractArray{T, 3},
+                        ξy::AbstractArray{T, 3}, ηy::AbstractArray{T, 3},
                         sJ::AbstractArray{T, 3},
                         nx::AbstractArray{T, 3}, ny::AbstractArray{T, 3},
                         D::AbstractMatrix{T}) where T
@@ -177,7 +177,7 @@ function computemetric!(x::AbstractArray{T, 3}, y::AbstractArray{T, 3},
   d = 2
 
   # we can resuse this storage
-  (ys, yr, xs, xr) = (rx, sx, ry, sy)
+  (ys, yr, xs, xr) = (ξx, ηx, ξy, ηy)
 
   for e = 1:nelem
     for n = 1:Nq
@@ -216,34 +216,34 @@ function computemetric!(x::AbstractArray{T, 3}, y::AbstractArray{T, 3},
     end
   end
   @. J = xr * ys - yr * xs
-  @. rx =  ys / J
-  @. sx = -yr / J
-  @. ry = -xs / J
-  @. sy =  xr / J
+  @. ξx =  ys / J
+  @. ηx = -yr / J
+  @. ξy = -xs / J
+  @. ηy =  xr / J
 
-  @views nx[:, 1, :] .= -J[ 1,  :, :] .* rx[ 1,  :, :]
-  @views ny[:, 1, :] .= -J[ 1,  :, :] .* ry[ 1,  :, :]
-  @views nx[:, 2, :] .=  J[Nq,  :, :] .* rx[Nq,  :, :]
-  @views ny[:, 2, :] .=  J[Nq,  :, :] .* ry[Nq,  :, :]
-  @views nx[:, 3, :] .= -J[ :,  1, :] .* sx[ :,  1, :]
-  @views ny[:, 3, :] .= -J[ :,  1, :] .* sy[ :,  1, :]
-  @views nx[:, 4, :] .=  J[ :, Nq, :] .* sx[ :, Nq, :]
-  @views ny[:, 4, :] .=  J[ :, Nq, :] .* sy[ :, Nq, :]
+  @views nx[:, 1, :] .= -J[ 1,  :, :] .* ξx[ 1,  :, :]
+  @views ny[:, 1, :] .= -J[ 1,  :, :] .* ξy[ 1,  :, :]
+  @views nx[:, 2, :] .=  J[Nq,  :, :] .* ξx[Nq,  :, :]
+  @views ny[:, 2, :] .=  J[Nq,  :, :] .* ξy[Nq,  :, :]
+  @views nx[:, 3, :] .= -J[ :,  1, :] .* ηx[ :,  1, :]
+  @views ny[:, 3, :] .= -J[ :,  1, :] .* ηy[ :,  1, :]
+  @views nx[:, 4, :] .=  J[ :, Nq, :] .* ηx[ :, Nq, :]
+  @views ny[:, 4, :] .=  J[ :, Nq, :] .* ηy[ :, Nq, :]
   @. sJ = hypot(nx, ny)
   @. nx = nx / sJ
   @. ny = ny / sJ
 
-  (J, rx, sx, ry, sy, sJ, nx, ny)
+  (J, ξx, ηx, ξy, ηy, sJ, nx, ny)
 end
 
 """
     computemetric!(x::AbstractArray{T, 4}, y::AbstractArray{T, 4},
                    z::AbstractArray{T, 4}, J::AbstractArray{T, 4},
-                   rx::AbstractArray{T, 4}, sx::AbstractArray{T, 4},
-                   tx::AbstractArray{T, 4} ry::AbstractArray{T, 4},
-                   sy::AbstractArray{T, 4}, ty::AbstractArray{T, 4}
-                   rz::AbstractArray{T, 4}, sz::AbstractArray{T, 4},
-                   tz::AbstractArray{T, 4} sJ::AbstractArray{T, 3},
+                   ξx::AbstractArray{T, 4}, ηx::AbstractArray{T, 4},
+                   ζx::AbstractArray{T, 4} ξy::AbstractArray{T, 4},
+                   ηy::AbstractArray{T, 4}, ζy::AbstractArray{T, 4}
+                   ξz::AbstractArray{T, 4}, ηz::AbstractArray{T, 4},
+                   ζz::AbstractArray{T, 4} sJ::AbstractArray{T, 3},
                    nx::AbstractArray{T, 3}, ny::AbstractArray{T, 3},
                    nz::AbstractArray{T, 3}, D::AbstractMatrix{T}) where T
 
@@ -252,7 +252,7 @@ the arrays are preallocated by the user and the (square) derivative matrix `D`
 should be consistent with the reference grid `r` used in [`creategrid!`](@ref).
 
 If `Nq = size(D, 1)` and `nelem = size(x, 4)` then the volume arrays `x`, `y`,
-`z`, `J`, `rx`, `sx`, `tx`, `ry`, `sy`, `ty`, `rz`, `sz`, and `tz` should all be
+`z`, `J`, `ξx`, `ηx`, `ζx`, `ξy`, `ηy`, `ζy`, `ξz`, `ηz`, and `ζz` should all be
 of size `(Nq, Nq, Nq, nelem)`.  Similarly, the face arrays `sJ`, `nx`, `ny`, and
 `nz` should be of size `(Nq^2, nfaces, nelem)` with `nfaces = 6`.
 
@@ -267,15 +267,15 @@ function computemetric!(x::AbstractArray{T, 4},
                         y::AbstractArray{T, 4},
                         z::AbstractArray{T, 4},
                         J::AbstractArray{T, 4},
-                        rx::AbstractArray{T, 4},
-                        sx::AbstractArray{T, 4},
-                        tx::AbstractArray{T, 4},
-                        ry::AbstractArray{T, 4},
-                        sy::AbstractArray{T, 4},
-                        ty::AbstractArray{T, 4},
-                        rz::AbstractArray{T, 4},
-                        sz::AbstractArray{T, 4},
-                        tz::AbstractArray{T, 4},
+                        ξx::AbstractArray{T, 4},
+                        ηx::AbstractArray{T, 4},
+                        ζx::AbstractArray{T, 4},
+                        ξy::AbstractArray{T, 4},
+                        ηy::AbstractArray{T, 4},
+                        ζy::AbstractArray{T, 4},
+                        ξz::AbstractArray{T, 4},
+                        ηz::AbstractArray{T, 4},
+                        ζz::AbstractArray{T, 4},
                         sJ::AbstractArray{T, 3},
                         nx::AbstractArray{T, 3},
                         ny::AbstractArray{T, 3},
@@ -284,9 +284,9 @@ function computemetric!(x::AbstractArray{T, 4},
 
   nelem = size(J, 4)
   Nq = size(D, 1)
-  (xr, xs, xt) = (rx, sx, tx)
-  (yr, ys, yt) = (ry, sy, ty)
-  (zr, zs, zt) = (rz, sz, tz)
+  (xr, xs, xt) = (ξx, ηx, ζx)
+  (yr, ys, yt) = (ξy, ηy, ζy)
+  (zr, zs, zt) = (ξz, ηz, ζz)
 
   for e = 1:nelem
     for m = 1:Nq
@@ -314,17 +314,17 @@ function computemetric!(x::AbstractArray{T, 4},
   (zxr, zxs, zxt) = (similar(JI2), similar(JI2), similar(JI2))
   (xyr, xys, xyt) = (similar(JI2), similar(JI2), similar(JI2))
 
-  # rx .= (Ds * yzt_zyt - Dt * yzs_zys) ./ (T(2) * J)
-  # sx .= (Dt * yzr_zyr - Dr * yzt_zyt) ./ (T(2) * J)
-  # tx .= (Dr * yzs_zys - Ds * yzr_zyr) ./ (T(2) * J)
+  # ξx .= (Ds * yzt_zyt - Dt * yzs_zys) ./ (T(2) * J)
+  # ηx .= (Dt * yzr_zyr - Dr * yzt_zyt) ./ (T(2) * J)
+  # ζx .= (Dr * yzs_zys - Ds * yzr_zyr) ./ (T(2) * J)
 
-  # ry .= (Ds * zxt_xzt - Dt * zxs_xzs) ./ (T(2) * J)
-  # sy .= (Dt * zxr_xzr - Dr * zxt_xzt) ./ (T(2) * J)
-  # ty .= (Dr * zxs_xzs - Ds * zxr_xzr) ./ (T(2) * J)
+  # ξy .= (Ds * zxt_xzt - Dt * zxs_xzs) ./ (T(2) * J)
+  # ηy .= (Dt * zxr_xzr - Dr * zxt_xzt) ./ (T(2) * J)
+  # ζy .= (Dr * zxs_xzs - Ds * zxr_xzr) ./ (T(2) * J)
 
-  # rz .= (Ds * xyt_yxt - Dt * xys_yxs) ./ (T(2) * J)
-  # sz .= (Dt * xyr_yxr - Dr * xyt_yxt) ./ (T(2) * J)
-  # tz .= (Dr * xys_yxs - Ds * xyr_yxr) ./ (T(2) * J)
+  # ξz .= (Ds * xyt_yxt - Dt * xys_yxs) ./ (T(2) * J)
+  # ηz .= (Dt * xyr_yxr - Dr * xyt_yxt) ./ (T(2) * J)
+  # ζz .= (Dr * xys_yxs - Ds * xyr_yxr) ./ (T(2) * J)
 
   for e = 1:nelem
     for k = 1:Nq
@@ -346,79 +346,79 @@ function computemetric!(x::AbstractArray{T, 4},
         end
       end
     end
-    @views rx[:, :, :, e] .= 0
-    @views sx[:, :, :, e] .= 0
-    @views tx[:, :, :, e] .= 0
-    @views ry[:, :, :, e] .= 0
-    @views sy[:, :, :, e] .= 0
-    @views ty[:, :, :, e] .= 0
-    @views rz[:, :, :, e] .= 0
-    @views sz[:, :, :, e] .= 0
-    @views tz[:, :, :, e] .= 0
+    @views ξx[:, :, :, e] .= 0
+    @views ηx[:, :, :, e] .= 0
+    @views ζx[:, :, :, e] .= 0
+    @views ξy[:, :, :, e] .= 0
+    @views ηy[:, :, :, e] .= 0
+    @views ζy[:, :, :, e] .= 0
+    @views ξz[:, :, :, e] .= 0
+    @views ηz[:, :, :, e] .= 0
+    @views ζz[:, :, :, e] .= 0
     for m = 1:Nq
       for n = 1:Nq
-        @views rx[n, :, m, e] += D * yzt[n, :, m]
-        @views rx[n, m, :, e] -= D * yzs[n, m, :]
+        @views ξx[n, :, m, e] += D * yzt[n, :, m]
+        @views ξx[n, m, :, e] -= D * yzs[n, m, :]
 
-        @views sx[n, m, :, e] += D * yzr[n, m, :]
-        @views sx[:, n, m, e] -= D * yzt[:, n, m]
+        @views ηx[n, m, :, e] += D * yzr[n, m, :]
+        @views ηx[:, n, m, e] -= D * yzt[:, n, m]
 
-        @views tx[:, n, m, e] += D * yzs[:, n, m]
-        @views tx[n, :, m, e] -= D * yzr[n, :, m]
+        @views ζx[:, n, m, e] += D * yzs[:, n, m]
+        @views ζx[n, :, m, e] -= D * yzr[n, :, m]
 
-        @views ry[n, :, m, e] += D * zxt[n, :, m]
-        @views ry[n, m, :, e] -= D * zxs[n, m, :]
+        @views ξy[n, :, m, e] += D * zxt[n, :, m]
+        @views ξy[n, m, :, e] -= D * zxs[n, m, :]
 
-        @views sy[n, m, :, e] += D * zxr[n, m, :]
-        @views sy[:, n, m, e] -= D * zxt[:, n, m]
+        @views ηy[n, m, :, e] += D * zxr[n, m, :]
+        @views ηy[:, n, m, e] -= D * zxt[:, n, m]
 
-        @views ty[:, n, m, e] += D * zxs[:, n, m]
-        @views ty[n, :, m, e] -= D * zxr[n, :, m]
+        @views ζy[:, n, m, e] += D * zxs[:, n, m]
+        @views ζy[n, :, m, e] -= D * zxr[n, :, m]
 
-        @views rz[n, :, m, e] += D * xyt[n, :, m]
-        @views rz[n, m, :, e] -= D * xys[n, m, :]
+        @views ξz[n, :, m, e] += D * xyt[n, :, m]
+        @views ξz[n, m, :, e] -= D * xys[n, m, :]
 
-        @views sz[n, m, :, e] += D * xyr[n, m, :]
-        @views sz[:, n, m, e] -= D * xyt[:, n, m]
+        @views ηz[n, m, :, e] += D * xyr[n, m, :]
+        @views ηz[:, n, m, e] -= D * xyt[:, n, m]
 
-        @views tz[:, n, m, e] += D * xys[:, n, m]
-        @views tz[n, :, m, e] -= D * xyr[n, :, m]
+        @views ζz[:, n, m, e] += D * xys[:, n, m]
+        @views ζz[n, :, m, e] -= D * xyr[n, :, m]
       end
     end
-    @views rx[:, :, :, e] = rx[:, :, :, e] .* JI2
-    @views sx[:, :, :, e] = sx[:, :, :, e] .* JI2
-    @views tx[:, :, :, e] = tx[:, :, :, e] .* JI2
-    @views ry[:, :, :, e] = ry[:, :, :, e] .* JI2
-    @views sy[:, :, :, e] = sy[:, :, :, e] .* JI2
-    @views ty[:, :, :, e] = ty[:, :, :, e] .* JI2
-    @views rz[:, :, :, e] = rz[:, :, :, e] .* JI2
-    @views sz[:, :, :, e] = sz[:, :, :, e] .* JI2
-    @views tz[:, :, :, e] = tz[:, :, :, e] .* JI2
+    @views ξx[:, :, :, e] = ξx[:, :, :, e] .* JI2
+    @views ηx[:, :, :, e] = ηx[:, :, :, e] .* JI2
+    @views ζx[:, :, :, e] = ζx[:, :, :, e] .* JI2
+    @views ξy[:, :, :, e] = ξy[:, :, :, e] .* JI2
+    @views ηy[:, :, :, e] = ηy[:, :, :, e] .* JI2
+    @views ζy[:, :, :, e] = ζy[:, :, :, e] .* JI2
+    @views ξz[:, :, :, e] = ξz[:, :, :, e] .* JI2
+    @views ηz[:, :, :, e] = ηz[:, :, :, e] .* JI2
+    @views ζz[:, :, :, e] = ζz[:, :, :, e] .* JI2
   end
 
   nx = reshape(nx, Nq, Nq, 6, nelem)
   ny = reshape(ny, Nq, Nq, 6, nelem)
   nz = reshape(nz, Nq, Nq, 6, nelem)
-  @views nx[:, :, 1, :] .= -J[ 1, :, :, :] .* rx[ 1, :, :, :]
-  @views nx[:, :, 2, :] .=  J[Nq, :, :, :] .* rx[Nq, :, :, :]
-  @views nx[:, :, 3, :] .= -J[ :, 1, :, :] .* sx[ :, 1, :, :]
-  @views nx[:, :, 4, :] .=  J[ :,Nq, :, :] .* sx[ :,Nq, :, :]
-  @views nx[:, :, 5, :] .= -J[ :, :, 1, :] .* tx[ :, :, 1, :]
-  @views nx[:, :, 6, :] .=  J[ :, :,Nq, :] .* tx[ :, :,Nq, :]
+  @views nx[:, :, 1, :] .= -J[ 1, :, :, :] .* ξx[ 1, :, :, :]
+  @views nx[:, :, 2, :] .=  J[Nq, :, :, :] .* ξx[Nq, :, :, :]
+  @views nx[:, :, 3, :] .= -J[ :, 1, :, :] .* ηx[ :, 1, :, :]
+  @views nx[:, :, 4, :] .=  J[ :,Nq, :, :] .* ηx[ :,Nq, :, :]
+  @views nx[:, :, 5, :] .= -J[ :, :, 1, :] .* ζx[ :, :, 1, :]
+  @views nx[:, :, 6, :] .=  J[ :, :,Nq, :] .* ζx[ :, :,Nq, :]
 
-  @views ny[:, :, 1, :] .= -J[ 1, :, :, :] .* ry[ 1, :, :, :]
-  @views ny[:, :, 2, :] .=  J[Nq, :, :, :] .* ry[Nq, :, :, :]
-  @views ny[:, :, 3, :] .= -J[ :, 1, :, :] .* sy[ :, 1, :, :]
-  @views ny[:, :, 4, :] .=  J[ :,Nq, :, :] .* sy[ :,Nq, :, :]
-  @views ny[:, :, 5, :] .= -J[ :, :, 1, :] .* ty[ :, :, 1, :]
-  @views ny[:, :, 6, :] .=  J[ :, :,Nq, :] .* ty[ :, :,Nq, :]
+  @views ny[:, :, 1, :] .= -J[ 1, :, :, :] .* ξy[ 1, :, :, :]
+  @views ny[:, :, 2, :] .=  J[Nq, :, :, :] .* ξy[Nq, :, :, :]
+  @views ny[:, :, 3, :] .= -J[ :, 1, :, :] .* ηy[ :, 1, :, :]
+  @views ny[:, :, 4, :] .=  J[ :,Nq, :, :] .* ηy[ :,Nq, :, :]
+  @views ny[:, :, 5, :] .= -J[ :, :, 1, :] .* ζy[ :, :, 1, :]
+  @views ny[:, :, 6, :] .=  J[ :, :,Nq, :] .* ζy[ :, :,Nq, :]
 
-  @views nz[:, :, 1, :] .= -J[ 1, :, :, :] .* rz[ 1, :, :, :]
-  @views nz[:, :, 2, :] .=  J[Nq, :, :, :] .* rz[Nq, :, :, :]
-  @views nz[:, :, 3, :] .= -J[ :, 1, :, :] .* sz[ :, 1, :, :]
-  @views nz[:, :, 4, :] .=  J[ :,Nq, :, :] .* sz[ :,Nq, :, :]
-  @views nz[:, :, 5, :] .= -J[ :, :, 1, :] .* tz[ :, :, 1, :]
-  @views nz[:, :, 6, :] .=  J[ :, :,Nq, :] .* tz[ :, :,Nq, :]
+  @views nz[:, :, 1, :] .= -J[ 1, :, :, :] .* ξz[ 1, :, :, :]
+  @views nz[:, :, 2, :] .=  J[Nq, :, :, :] .* ξz[Nq, :, :, :]
+  @views nz[:, :, 3, :] .= -J[ :, 1, :, :] .* ηz[ :, 1, :, :]
+  @views nz[:, :, 4, :] .=  J[ :,Nq, :, :] .* ηz[ :,Nq, :, :]
+  @views nz[:, :, 5, :] .= -J[ :, :, 1, :] .* ζz[ :, :, 1, :]
+  @views nz[:, :, 6, :] .=  J[ :, :,Nq, :] .* ζz[ :, :,Nq, :]
   nx = reshape(nx, Nq * Nq, 6, nelem)
   ny = reshape(ny, Nq * Nq, 6, nelem)
   nz = reshape(nz, Nq * Nq, 6, nelem)
@@ -428,7 +428,7 @@ function computemetric!(x::AbstractArray{T, 4},
   @. ny = ny / sJ
   @. nz = nz / sJ
 
-  (J, rx, sx, tx, ry, sy, ty, rz, sz, tz, sJ, nx, ny, nz)
+  (J, ξx, ηx, ζx, ξy, ηy, ζy, ξz, ηz, ζz, sJ, nx, ny, nz)
 end
 
 creategrid1d(elemtocoord, r) = creategrid(Val(1), elemtocoord, r)
@@ -508,7 +508,7 @@ reference grid `r` used in [`creategrid!`](@ref).
 The metric terms are returned as a 'NamedTuple` of the following arrays:
 
  - `J` the Jacobian determinant
- - `rx` derivative ∂r / ∂x'
+ - `ξx` derivative ∂r / ∂x'
  - `sJ` the surface Jacobian
  - 'nx` outward pointing unit normal in \$x\$-direction
 """
@@ -520,14 +520,14 @@ function computemetric(x::AbstractArray{T, 2},
   nface = 2
 
   J = similar(x)
-  rx = similar(x)
+  ξx = similar(x)
 
   sJ = Array{T, 3}(undef, 1, nface, nelem)
   nx = Array{T, 3}(undef, 1, nface, nelem)
 
-  computemetric!(x, J, rx, sJ, nx, D)
+  computemetric!(x, J, ξx, sJ, nx, D)
 
-  (J=J, rx=rx, sJ=sJ, nx=nx)
+  (J=J, ξx=ξx, sJ=sJ, nx=nx)
 end
 
 
@@ -542,10 +542,10 @@ reference grid `r` used in [`creategrid!`](@ref).
 The metric terms are returned as a 'NamedTuple` of the following arrays:
 
  - `J` the Jacobian determinant
- - `rx` derivative ∂r / ∂x'
- - `sx` derivative ∂s / ∂x'
- - `ry` derivative ∂r / ∂y'
- - `sy` derivative ∂s / ∂y'
+ - `ξx` derivative ∂r / ∂x'
+ - `ηx` derivative ∂s / ∂x'
+ - `ξy` derivative ∂r / ∂y'
+ - `ηy` derivative ∂s / ∂y'
  - `sJ` the surface Jacobian
  - 'nx` outward pointing unit normal in \$x\$-direction
  - 'ny` outward pointing unit normal in \$y\$-direction
@@ -559,18 +559,18 @@ function computemetric(x::AbstractArray{T, 3},
   nface = 4
 
   J = similar(x)
-  rx = similar(x)
-  sx = similar(x)
-  ry = similar(x)
-  sy = similar(x)
+  ξx = similar(x)
+  ηx = similar(x)
+  ξy = similar(x)
+  ηy = similar(x)
 
   sJ = Array{T, 3}(undef, Nq, nface, nelem)
   nx = Array{T, 3}(undef, Nq, nface, nelem)
   ny = Array{T, 3}(undef, Nq, nface, nelem)
 
-  computemetric!(x, y, J, rx, sx, ry, sy, sJ, nx, ny, D)
+  computemetric!(x, y, J, ξx, ηx, ξy, ηy, sJ, nx, ny, D)
 
-  (J=J, rx=rx, sx=sx, ry=ry, sy=sy, sJ=sJ, nx=nx, ny=ny)
+  (J=J, ξx=ξx, ηx=ηx, ξy=ξy, ηy=ηy, sJ=sJ, nx=nx, ny=ny)
 end
 
 """
@@ -584,15 +584,15 @@ with the reference grid `r` used in [`creategrid!`](@ref).
 The metric terms are returned as a 'NamedTuple` of the following arrays:
 
  - `J` the Jacobian determinant
- - `rx` derivative ∂r / ∂x'
- - `sx` derivative ∂s / ∂x'
- - `tx` derivative ∂t / ∂x'
- - `ry` derivative ∂r / ∂y'
- - `sy` derivative ∂s / ∂y'
- - `ty` derivative ∂t / ∂y'
- - `rz` derivative ∂r / ∂z'
- - `sz` derivative ∂s / ∂z'
- - `tz` derivative ∂t / ∂z'
+ - `ξx` derivative ∂r / ∂x'
+ - `ηx` derivative ∂s / ∂x'
+ - `ζx` derivative ∂t / ∂x'
+ - `ξy` derivative ∂r / ∂y'
+ - `ηy` derivative ∂s / ∂y'
+ - `ζy` derivative ∂t / ∂y'
+ - `ξz` derivative ∂r / ∂z'
+ - `ηz` derivative ∂s / ∂z'
+ - `ζz` derivative ∂t / ∂z'
  - `sJ` the surface Jacobian
  - 'nx` outward pointing unit normal in \$x\$-direction
  - 'ny` outward pointing unit normal in \$y\$-direction
@@ -609,24 +609,24 @@ function computemetric(x::AbstractArray{T, 4},
   nface = 6
 
   J = similar(x)
-  rx = similar(x)
-  sx = similar(x)
-  tx = similar(x)
-  ry = similar(x)
-  sy = similar(x)
-  ty = similar(x)
-  rz = similar(x)
-  sz = similar(x)
-  tz = similar(x)
+  ξx = similar(x)
+  ηx = similar(x)
+  ζx = similar(x)
+  ξy = similar(x)
+  ηy = similar(x)
+  ζy = similar(x)
+  ξz = similar(x)
+  ηz = similar(x)
+  ζz = similar(x)
 
   sJ = Array{T, 3}(undef, Nq^2, nface, nelem)
   nx = Array{T, 3}(undef, Nq^2, nface, nelem)
   ny = Array{T, 3}(undef, Nq^2, nface, nelem)
   nz = Array{T, 3}(undef, Nq^2, nface, nelem)
 
-  computemetric!(x, y, z, J, rx, sx, tx, ry, sy, ty, rz, sz, tz, sJ,
+  computemetric!(x, y, z, J, ξx, ηx, ζx, ξy, ηy, ζy, ξz, ηz, ζz, sJ,
                  nx, ny, nz, D)
 
-  (J=J, rx=rx, sx=sx, tx=tx, ry=ry, sy=sy, ty=ty, rz=rz, sz=sz, tz=tz, sJ=sJ,
+  (J=J, ξx=ξx, ηx=ηx, ζx=ζx, ξy=ξy, ηy=ηy, ζy=ζy, ξz=ξz, ηz=ηz, ζz=ζz, sJ=sJ,
    nx=nx, ny=ny, nz=nz)
 end

--- a/test/test_metric.jl
+++ b/test/test_metric.jl
@@ -1,8 +1,8 @@
-const VGEO2D = (x=1, y=2, J=3, rx=4, sx=5, ry=6, sy=7)
+const VGEO2D = (x=1, y=2, J=3, ξx=4, ηx=5, ξy=6, ηy=7)
 const SGEO2D = (sJ = 1, nx = 2, ny = 3)
 
-const VGEO3D = (x = 1, y = 2, z = 3, J = 4, rx = 5, sx = 6, tx = 7, ry = 8,
-                sy = 9, ty = 10, rz = 11, sz = 12, tz = 13)
+const VGEO3D = (x = 1, y = 2, z = 3, J = 4, ξx = 5, ηx = 6, ζx = 7, ξy = 8,
+                ηy = 9, ζy = 10, ξz = 11, ηz = 12, ζz = 13)
 const SGEO3D = (sJ = 1, nx = 2, ny = 3, nz = 4)
 
 @testset "1-D Metric terms" begin
@@ -29,8 +29,8 @@ const SGEO3D = (sJ = 1, nx = 2, ny = 3, nz = 4)
       metric = Canary.computemetric(x, D)
       @test metric.J[:, 1] ≈ ones(T, Nq) / 2
       @test metric.J[:, 2] ≈ 5 * ones(T, Nq)
-      @test metric.rx[:, 1] ≈ 2 * ones(T, Nq)
-      @test metric.rx[:, 2] ≈ ones(T, Nq) / 5
+      @test metric.ξx[:, 1] ≈ 2 * ones(T, Nq)
+      @test metric.ξx[:, 2] ≈ ones(T, Nq) / 5
       @test metric.nx[1, 1, :] ≈ -ones(T, nelem)
       @test metric.nx[1, 2, :] ≈  ones(T, nelem)
       @test metric.sJ[1, 1, :] ≈  ones(T, nelem)
@@ -74,21 +74,21 @@ end
 
       J_exact = ones(Int, 3, 3, 4)
 
-      rx_exact = zeros(Int, 3, 3, 4)
-      rx_exact[:, :, 1] .= 1
-      rx_exact[:, :, 3] .= -1
+      ξx_exact = zeros(Int, 3, 3, 4)
+      ξx_exact[:, :, 1] .= 1
+      ξx_exact[:, :, 3] .= -1
 
-      ry_exact = zeros(Int, 3, 3, 4)
-      ry_exact[:, :, 2] .= 1
-      ry_exact[:, :, 4] .= -1
+      ξy_exact = zeros(Int, 3, 3, 4)
+      ξy_exact[:, :, 2] .= 1
+      ξy_exact[:, :, 4] .= -1
 
-      sx_exact = zeros(Int, 3, 3, 4)
-      sx_exact[:, :, 2] .= -1
-      sx_exact[:, :, 4] .= 1
+      ηx_exact = zeros(Int, 3, 3, 4)
+      ηx_exact[:, :, 2] .= -1
+      ηx_exact[:, :, 4] .= 1
 
-      sy_exact = zeros(Int, 3, 3, 4)
-      sy_exact[:, :, 1] .= 1
-      sy_exact[:, :, 3] .= -1
+      ηy_exact = zeros(Int, 3, 3, 4)
+      ηy_exact[:, :, 1] .= 1
+      ηy_exact[:, :, 3] .= -1
 
       sJ_exact = ones(Int, Nq, nfaces, nelem)
 
@@ -122,10 +122,10 @@ end
       @test (@view vgeo[:,:,VGEO2D.x,:]) ≈ x_exact
       @test (@view vgeo[:,:,VGEO2D.y,:]) ≈ y_exact
       @test (@view vgeo[:, :, VGEO2D.J, :]) ≈ J_exact
-      @test (@view vgeo[:, :, VGEO2D.rx, :]) ≈ rx_exact
-      @test (@view vgeo[:, :, VGEO2D.ry, :]) ≈ ry_exact
-      @test (@view vgeo[:, :, VGEO2D.sx, :]) ≈ sx_exact
-      @test (@view vgeo[:, :, VGEO2D.sy, :]) ≈ sy_exact
+      @test (@view vgeo[:, :, VGEO2D.ξx, :]) ≈ ξx_exact
+      @test (@view vgeo[:, :, VGEO2D.ξy, :]) ≈ ξy_exact
+      @test (@view vgeo[:, :, VGEO2D.ηx, :]) ≈ ηx_exact
+      @test (@view vgeo[:, :, VGEO2D.ηy, :]) ≈ ηy_exact
       @test (@view sgeo[:, :, SGEO2D.sJ, :]) ≈ sJ_exact
       @test (@view sgeo[:, :, SGEO2D.nx, :]) ≈ nx_exact
       @test (@view sgeo[:, :, SGEO2D.ny, :]) ≈ ny_exact
@@ -171,10 +171,10 @@ end
                             ntuple(j->(@view sgeo[:, :, j, :]), length(SGEO2D))...,
       D)
       @test J ≈ (@view vgeo[:, :, VGEO2D.J, :])
-      @test (@view vgeo[:, :, VGEO2D.rx, :]) ≈  ys ./ J
-      @test (@view vgeo[:, :, VGEO2D.sx, :]) ≈ -yr ./ J
-      @test (@view vgeo[:, :, VGEO2D.ry, :]) ≈ -xs ./ J
-      @test (@view vgeo[:, :, VGEO2D.sy, :]) ≈  xr ./ J
+      @test (@view vgeo[:, :, VGEO2D.ξx, :]) ≈  ys ./ J
+      @test (@view vgeo[:, :, VGEO2D.ηx, :]) ≈ -yr ./ J
+      @test (@view vgeo[:, :, VGEO2D.ξy, :]) ≈ -xs ./ J
+      @test (@view vgeo[:, :, VGEO2D.ηy, :]) ≈  xr ./ J
 
       # check the normals?
       nx = @view sgeo[:,:,SGEO2D.nx,:]
@@ -221,10 +221,10 @@ end
 
       metric = Canary.computemetric(x, y, D)
       @test J ≈ metric.J
-      @test metric.rx ≈  ys ./ J
-      @test metric.sx ≈ -yr ./ J
-      @test metric.ry ≈ -xs ./ J
-      @test metric.sy ≈  xr ./ J
+      @test metric.ξx ≈  ys ./ J
+      @test metric.ηx ≈ -yr ./ J
+      @test metric.ξy ≈ -xs ./ J
+      @test metric.ηy ≈  xr ./ J
 
       # check the normals?
       nx = metric.nx
@@ -282,18 +282,18 @@ end
     (Cx, Cy) = (zeros(T, Nq, Nq), zeros(T, Nq, Nq))
 
     J  = @view vgeo[:,:,VGEO2D.J ,:]
-    rx = @view vgeo[:,:,VGEO2D.rx,:]
-    ry = @view vgeo[:,:,VGEO2D.ry,:]
-    sx = @view vgeo[:,:,VGEO2D.sx,:]
-    sy = @view vgeo[:,:,VGEO2D.sy,:]
+    ξx = @view vgeo[:,:,VGEO2D.ξx,:]
+    ξy = @view vgeo[:,:,VGEO2D.ξy,:]
+    ηx = @view vgeo[:,:,VGEO2D.ηx,:]
+    ηy = @view vgeo[:,:,VGEO2D.ηy,:]
 
     e = 1
     for n = 1:Nq
-      Cx[:, n] += D * (J[:, n, e] .* rx[:, n, e])
-      Cx[n, :] += D * (J[n, :, e] .* sx[n, :, e])
+      Cx[:, n] += D * (J[:, n, e] .* ξx[:, n, e])
+      Cx[n, :] += D * (J[n, :, e] .* ηx[n, :, e])
 
-      Cy[:, n] += D * (J[:, n, e] .* rx[:, n, e])
-      Cy[n, :] += D * (J[n, :, e] .* sx[n, :, e])
+      Cy[:, n] += D * (J[:, n, e] .* ξx[:, n, e])
+      Cy[n, :] += D * (J[n, :, e] .* ηx[n, :, e])
     end
     @test maximum(abs.(Cx)) ≤ 1000 * eps(T)
     @test maximum(abs.(Cy)) ≤ 1000 * eps(T)
@@ -332,19 +332,19 @@ end
       x_exact[:, 2, :, 2] .= 1
       x_exact[:, 3, :, 2] .= 0
 
-      rx_exact = zeros(Int, 3, 3, 3, nelem)
-      rx_exact[:, :, :, 1] .= 1
+      ξx_exact = zeros(Int, 3, 3, 3, nelem)
+      ξx_exact[:, :, :, 1] .= 1
 
-      ry_exact = zeros(Int, 3, 3, 3, nelem)
-      ry_exact[:, :, :, 2] .= 1
+      ξy_exact = zeros(Int, 3, 3, 3, nelem)
+      ξy_exact[:, :, :, 2] .= 1
 
-      sx_exact = zeros(Int, 3, 3, 3, nelem)
-      sx_exact[:, :, :, 2] .= -1
+      ηx_exact = zeros(Int, 3, 3, 3, nelem)
+      ηx_exact[:, :, :, 2] .= -1
 
-      sy_exact = zeros(Int, 3, 3, 3, nelem)
-      sy_exact[:, :, :, 1] .= 1
+      ηy_exact = zeros(Int, 3, 3, 3, nelem)
+      ηy_exact[:, :, :, 1] .= 1
 
-      tz_exact = ones(Int, 3, 3, 3, nelem)
+      ζz_exact = ones(Int, 3, 3, 3, nelem)
 
       y_exact = Array{Int, 4}(undef, 3, 3, 3, nelem)
       y_exact[:, 1, :, 1] .= 0
@@ -391,15 +391,15 @@ end
       @test (@view vgeo[:,:,:,VGEO3D.y,:]) ≈ y_exact
       @test (@view vgeo[:,:,:,VGEO3D.z,:]) ≈ z_exact
       @test (@view vgeo[:,:,:,VGEO3D.J,:]) ≈ J_exact
-      @test (@view vgeo[:,:,:,VGEO3D.rx,:]) ≈ rx_exact
-      @test (@view vgeo[:,:,:,VGEO3D.ry,:]) ≈ ry_exact
-      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.rz,:])) ≤ 10 * eps(T)
-      @test (@view vgeo[:,:,:,VGEO3D.sx,:]) ≈ sx_exact
-      @test (@view vgeo[:,:,:,VGEO3D.sy,:]) ≈ sy_exact
-      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.sz,:])) ≤ 10 * eps(T)
-      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.tx,:])) ≤ 10 * eps(T)
-      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.ty,:])) ≤ 10 * eps(T)
-      @test (@view vgeo[:,:,:,VGEO3D.tz,:]) ≈ tz_exact
+      @test (@view vgeo[:,:,:,VGEO3D.ξx,:]) ≈ ξx_exact
+      @test (@view vgeo[:,:,:,VGEO3D.ξy,:]) ≈ ξy_exact
+      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.ξz,:])) ≤ 10 * eps(T)
+      @test (@view vgeo[:,:,:,VGEO3D.ηx,:]) ≈ ηx_exact
+      @test (@view vgeo[:,:,:,VGEO3D.ηy,:]) ≈ ηy_exact
+      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.ηz,:])) ≤ 10 * eps(T)
+      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.ζx,:])) ≤ 10 * eps(T)
+      @test maximum(abs.(@view vgeo[:,:,:,VGEO3D.ζy,:])) ≤ 10 * eps(T)
+      @test (@view vgeo[:,:,:,VGEO3D.ζz,:]) ≈ ζz_exact
       @test (@view sgeo[:,:,:,SGEO3D.sJ,:]) ≈ sJ_exact
       @test (@view sgeo[:,:,:,SGEO3D.nx,:]) ≈ nx_exact
       @test (@view sgeo[:,:,:,SGEO3D.ny,:]) ≈ ny_exact
@@ -469,7 +469,7 @@ end
       Je = ones(Int, 3, 3, 3, nelem)
 
       # By construction
-      # Q = [xr xs ys; yr ys yt; zr zs zt] = [rx sx tx; ry sy ty; rz sz tz]
+      # Q = [xr xs ys; yr ys yt; zr zs zt] = [ξx ηx ζx; ξy ηy ζy; ξz ηz ζz]
       rxe = fill(Q[1,1], 3, 3, 3, nelem)
       rye = fill(Q[2,1], 3, 3, 3, nelem)
       rze = fill(Q[3,1], 3, 3, 3, nelem)
@@ -517,15 +517,15 @@ end
       @test (@view vgeo[:,:,:,VGEO3D.y,:]) ≈ ye
       @test (@view vgeo[:,:,:,VGEO3D.z,:]) ≈ ze
       @test (@view vgeo[:,:,:,VGEO3D.J,:]) ≈ Je
-      @test (@view vgeo[:,:,:,VGEO3D.rx,:]) ≈ rxe
-      @test (@view vgeo[:,:,:,VGEO3D.ry,:]) ≈ rye
-      @test (@view vgeo[:,:,:,VGEO3D.rz,:]) ≈ rze
-      @test (@view vgeo[:,:,:,VGEO3D.sx,:]) ≈ sxe
-      @test (@view vgeo[:,:,:,VGEO3D.sy,:]) ≈ sye
-      @test (@view vgeo[:,:,:,VGEO3D.sz,:]) ≈ sze
-      @test (@view vgeo[:,:,:,VGEO3D.tx,:]) ≈ txe
-      @test (@view vgeo[:,:,:,VGEO3D.ty,:]) ≈ tye
-      @test (@view vgeo[:,:,:,VGEO3D.tz,:]) ≈ tze
+      @test (@view vgeo[:,:,:,VGEO3D.ξx,:]) ≈ rxe
+      @test (@view vgeo[:,:,:,VGEO3D.ξy,:]) ≈ rye
+      @test (@view vgeo[:,:,:,VGEO3D.ξz,:]) ≈ rze
+      @test (@view vgeo[:,:,:,VGEO3D.ηx,:]) ≈ sxe
+      @test (@view vgeo[:,:,:,VGEO3D.ηy,:]) ≈ sye
+      @test (@view vgeo[:,:,:,VGEO3D.ηz,:]) ≈ sze
+      @test (@view vgeo[:,:,:,VGEO3D.ζx,:]) ≈ txe
+      @test (@view vgeo[:,:,:,VGEO3D.ζy,:]) ≈ tye
+      @test (@view vgeo[:,:,:,VGEO3D.ζz,:]) ≈ tze
       @test (@view sgeo[:,:,:,SGEO3D.sJ,:]) ≈ sJe
       @test (@view sgeo[:,:,:,SGEO3D.nx,:]) ≈ nxe
       @test (@view sgeo[:,:,:,SGEO3D.ny,:]) ≈ nye
@@ -583,15 +583,15 @@ end
            yr .* (zs .* xt - zt .* xs) +
            zr .* (xs .* yt - xt .* ys))
 
-      rx =  (ys .* zt - yt .* zs) ./ J
-      ry =  (zs .* xt - zt .* xs) ./ J
-      rz =  (xs .* yt - xt .* ys) ./ J
-      sx =  (yt .* zr - yr .* zt) ./ J
-      sy =  (zt .* xr - zr .* xt) ./ J
-      sz =  (xt .* yr - xr .* yt) ./ J
-      tx =  (yr .* zs - ys .* zr) ./ J
-      ty =  (zr .* xs - zs .* xr) ./ J
-      tz =  (xr .* ys - xs .* yr) ./ J
+      ξx =  (ys .* zt - yt .* zs) ./ J
+      ξy =  (zs .* xt - zt .* xs) ./ J
+      ξz =  (xs .* yt - xt .* ys) ./ J
+      ηx =  (yt .* zr - yr .* zt) ./ J
+      ηy =  (zt .* xr - zr .* xt) ./ J
+      ηz =  (xt .* yr - xr .* yt) ./ J
+      ζx =  (yr .* zs - ys .* zr) ./ J
+      ζy =  (zr .* xs - zs .* xr) ./ J
+      ζz =  (xr .* ys - xs .* yr) ./ J
 
       foreach(j->(x[j], y[j], z[j]) = f(x[j], y[j], z[j]), 1:length(x))
 
@@ -601,15 +601,15 @@ end
       sgeo = reshape(sgeo, Nq, Nq, nfaces, length(SGEO3D), nelem)
 
       @test (@view vgeo[:,:,:,VGEO3D.J,:]) ≈ J
-      @test (@view vgeo[:,:,:,VGEO3D.rx,:]) ≈ rx
-      @test (@view vgeo[:,:,:,VGEO3D.ry,:]) ≈ ry
-      @test (@view vgeo[:,:,:,VGEO3D.rz,:]) ≈ rz
-      @test (@view vgeo[:,:,:,VGEO3D.sx,:]) ≈ sx
-      @test (@view vgeo[:,:,:,VGEO3D.sy,:]) ≈ sy
-      @test (@view vgeo[:,:,:,VGEO3D.sz,:]) ≈ sz
-      @test (@view vgeo[:,:,:,VGEO3D.tx,:]) ≈ tx
-      @test (@view vgeo[:,:,:,VGEO3D.ty,:]) ≈ ty
-      @test (@view vgeo[:,:,:,VGEO3D.tz,:]) ≈ tz
+      @test (@view vgeo[:,:,:,VGEO3D.ξx,:]) ≈ ξx
+      @test (@view vgeo[:,:,:,VGEO3D.ξy,:]) ≈ ξy
+      @test (@view vgeo[:,:,:,VGEO3D.ξz,:]) ≈ ξz
+      @test (@view vgeo[:,:,:,VGEO3D.ηx,:]) ≈ ηx
+      @test (@view vgeo[:,:,:,VGEO3D.ηy,:]) ≈ ηy
+      @test (@view vgeo[:,:,:,VGEO3D.ηz,:]) ≈ ηz
+      @test (@view vgeo[:,:,:,VGEO3D.ζx,:]) ≈ ζx
+      @test (@view vgeo[:,:,:,VGEO3D.ζy,:]) ≈ ζy
+      @test (@view vgeo[:,:,:,VGEO3D.ζz,:]) ≈ ζz
       nx = @view sgeo[:,:,:,SGEO3D.nx,:]
       ny = @view sgeo[:,:,:,SGEO3D.ny,:]
       nz = @view sgeo[:,:,:,SGEO3D.nz,:]
@@ -617,24 +617,24 @@ end
       @test hypot.(nx, ny, nz) ≈ ones(T, size(nx))
       @test ([sJ[:,:,1,:] .* nx[:,:,1,:], sJ[:,:,1,:] .* ny[:,:,1,:],
               sJ[:,:,1,:] .* nz[:,:,1,:]] ≈
-             [-J[ 1,:,:,:] .* rx[ 1,:,:,:], -J[ 1,:,:,:] .* ry[ 1,:,:,:],
-              -J[ 1,:,:,:] .* rz[ 1,:,:,:]])
+             [-J[ 1,:,:,:] .* ξx[ 1,:,:,:], -J[ 1,:,:,:] .* ξy[ 1,:,:,:],
+              -J[ 1,:,:,:] .* ξz[ 1,:,:,:]])
       @test ([sJ[:,:,2,:] .* nx[:,:,2,:], sJ[:,:,2,:] .* ny[:,:,2,:],
               sJ[:,:,2,:] .* nz[:,:,2,:]] ≈
-             [ J[Nq,:,:,:] .* rx[Nq,:,:,:],  J[Nq,:,:,:] .* ry[Nq,:,:,:],
-               J[Nq,:,:,:] .* rz[Nq,:,:,:]])
-      @test sJ[:,:,3,:] .* nx[:,:,3,:] ≈ -J[:, 1,:,:] .* sx[:, 1,:,:]
-      @test sJ[:,:,3,:] .* ny[:,:,3,:] ≈ -J[:, 1,:,:] .* sy[:, 1,:,:]
-      @test sJ[:,:,3,:] .* nz[:,:,3,:] ≈ -J[:, 1,:,:] .* sz[:, 1,:,:]
-      @test sJ[:,:,4,:] .* nx[:,:,4,:] ≈  J[:,Nq,:,:] .* sx[:,Nq,:,:]
-      @test sJ[:,:,4,:] .* ny[:,:,4,:] ≈  J[:,Nq,:,:] .* sy[:,Nq,:,:]
-      @test sJ[:,:,4,:] .* nz[:,:,4,:] ≈  J[:,Nq,:,:] .* sz[:,Nq,:,:]
-      @test sJ[:,:,5,:] .* nx[:,:,5,:] ≈ -J[:,:, 1,:] .* tx[:,:, 1,:]
-      @test sJ[:,:,5,:] .* ny[:,:,5,:] ≈ -J[:,:, 1,:] .* ty[:,:, 1,:]
-      @test sJ[:,:,5,:] .* nz[:,:,5,:] ≈ -J[:,:, 1,:] .* tz[:,:, 1,:]
-      @test sJ[:,:,6,:] .* nx[:,:,6,:] ≈  J[:,:,Nq,:] .* tx[:,:,Nq,:]
-      @test sJ[:,:,6,:] .* ny[:,:,6,:] ≈  J[:,:,Nq,:] .* ty[:,:,Nq,:]
-      @test sJ[:,:,6,:] .* nz[:,:,6,:] ≈  J[:,:,Nq,:] .* tz[:,:,Nq,:]
+             [ J[Nq,:,:,:] .* ξx[Nq,:,:,:],  J[Nq,:,:,:] .* ξy[Nq,:,:,:],
+               J[Nq,:,:,:] .* ξz[Nq,:,:,:]])
+      @test sJ[:,:,3,:] .* nx[:,:,3,:] ≈ -J[:, 1,:,:] .* ηx[:, 1,:,:]
+      @test sJ[:,:,3,:] .* ny[:,:,3,:] ≈ -J[:, 1,:,:] .* ηy[:, 1,:,:]
+      @test sJ[:,:,3,:] .* nz[:,:,3,:] ≈ -J[:, 1,:,:] .* ηz[:, 1,:,:]
+      @test sJ[:,:,4,:] .* nx[:,:,4,:] ≈  J[:,Nq,:,:] .* ηx[:,Nq,:,:]
+      @test sJ[:,:,4,:] .* ny[:,:,4,:] ≈  J[:,Nq,:,:] .* ηy[:,Nq,:,:]
+      @test sJ[:,:,4,:] .* nz[:,:,4,:] ≈  J[:,Nq,:,:] .* ηz[:,Nq,:,:]
+      @test sJ[:,:,5,:] .* nx[:,:,5,:] ≈ -J[:,:, 1,:] .* ζx[:,:, 1,:]
+      @test sJ[:,:,5,:] .* ny[:,:,5,:] ≈ -J[:,:, 1,:] .* ζy[:,:, 1,:]
+      @test sJ[:,:,5,:] .* nz[:,:,5,:] ≈ -J[:,:, 1,:] .* ζz[:,:, 1,:]
+      @test sJ[:,:,6,:] .* nx[:,:,6,:] ≈  J[:,:,Nq,:] .* ζx[:,:,Nq,:]
+      @test sJ[:,:,6,:] .* ny[:,:,6,:] ≈  J[:,:,Nq,:] .* ζy[:,:,Nq,:]
+      @test sJ[:,:,6,:] .* nz[:,:,6,:] ≈  J[:,:,Nq,:] .* ζz[:,:,Nq,:]
     end
   end
   #}}}
@@ -682,30 +682,30 @@ end
            yr .* (zs .* xt - zt .* xs) +
            zr .* (xs .* yt - xt .* ys))
 
-      rx =  (ys .* zt - yt .* zs) ./ J
-      ry =  (zs .* xt - zt .* xs) ./ J
-      rz =  (xs .* yt - xt .* ys) ./ J
-      sx =  (yt .* zr - yr .* zt) ./ J
-      sy =  (zt .* xr - zr .* xt) ./ J
-      sz =  (xt .* yr - xr .* yt) ./ J
-      tx =  (yr .* zs - ys .* zr) ./ J
-      ty =  (zr .* xs - zs .* xr) ./ J
-      tz =  (xr .* ys - xs .* yr) ./ J
+      ξx =  (ys .* zt - yt .* zs) ./ J
+      ξy =  (zs .* xt - zt .* xs) ./ J
+      ξz =  (xs .* yt - xt .* ys) ./ J
+      ηx =  (yt .* zr - yr .* zt) ./ J
+      ηy =  (zt .* xr - zr .* xt) ./ J
+      ηz =  (xt .* yr - xr .* yt) ./ J
+      ζx =  (yr .* zs - ys .* zr) ./ J
+      ζy =  (zr .* xs - zs .* xr) ./ J
+      ζz =  (xr .* ys - xs .* yr) ./ J
 
       foreach(j->(x[j], y[j], z[j]) = f(x[j], y[j], z[j]), 1:length(x))
 
       metric = computemetric(x, y, z, D)
 
       @test metric.J ≈ J
-      @test metric.rx ≈ rx
-      @test metric.ry ≈ ry
-      @test metric.rz ≈ rz
-      @test metric.sx ≈ sx
-      @test metric.sy ≈ sy
-      @test metric.sz ≈ sz
-      @test metric.tx ≈ tx
-      @test metric.ty ≈ ty
-      @test metric.tz ≈ tz
+      @test metric.ξx ≈ ξx
+      @test metric.ξy ≈ ξy
+      @test metric.ξz ≈ ξz
+      @test metric.ηx ≈ ηx
+      @test metric.ηy ≈ ηy
+      @test metric.ηz ≈ ηz
+      @test metric.ζx ≈ ζx
+      @test metric.ζy ≈ ζy
+      @test metric.ζz ≈ ζz
       ind = LinearIndices((1:Nq, 1:Nq))
       nx = metric.nx
       ny = metric.ny
@@ -714,24 +714,24 @@ end
       @test hypot.(nx, ny, nz) ≈ ones(T, size(nx))
       @test ([sJ[ind,1,:] .* nx[ind,1,:], sJ[ind,1,:] .* ny[ind,1,:],
               sJ[ind,1,:] .* nz[ind,1,:]] ≈
-             [-J[ 1,:,:,:] .* rx[ 1,:,:,:], -J[ 1,:,:,:] .* ry[ 1,:,:,:],
-              -J[ 1,:,:,:] .* rz[ 1,:,:,:]])
+             [-J[ 1,:,:,:] .* ξx[ 1,:,:,:], -J[ 1,:,:,:] .* ξy[ 1,:,:,:],
+              -J[ 1,:,:,:] .* ξz[ 1,:,:,:]])
       @test ([sJ[ind,2,:] .* nx[ind,2,:], sJ[ind,2,:] .* ny[ind,2,:],
               sJ[ind,2,:] .* nz[ind,2,:]] ≈
-             [ J[Nq,:,:,:] .* rx[Nq,:,:,:],  J[Nq,:,:,:] .* ry[Nq,:,:,:],
-               J[Nq,:,:,:] .* rz[Nq,:,:,:]])
-      @test sJ[ind,3,:] .* nx[ind,3,:] ≈ -J[:, 1,:,:] .* sx[:, 1,:,:]
-      @test sJ[ind,3,:] .* ny[ind,3,:] ≈ -J[:, 1,:,:] .* sy[:, 1,:,:]
-      @test sJ[ind,3,:] .* nz[ind,3,:] ≈ -J[:, 1,:,:] .* sz[:, 1,:,:]
-      @test sJ[ind,4,:] .* nx[ind,4,:] ≈  J[:,Nq,:,:] .* sx[:,Nq,:,:]
-      @test sJ[ind,4,:] .* ny[ind,4,:] ≈  J[:,Nq,:,:] .* sy[:,Nq,:,:]
-      @test sJ[ind,4,:] .* nz[ind,4,:] ≈  J[:,Nq,:,:] .* sz[:,Nq,:,:]
-      @test sJ[ind,5,:] .* nx[ind,5,:] ≈ -J[:,:, 1,:] .* tx[:,:, 1,:]
-      @test sJ[ind,5,:] .* ny[ind,5,:] ≈ -J[:,:, 1,:] .* ty[:,:, 1,:]
-      @test sJ[ind,5,:] .* nz[ind,5,:] ≈ -J[:,:, 1,:] .* tz[:,:, 1,:]
-      @test sJ[ind,6,:] .* nx[ind,6,:] ≈  J[:,:,Nq,:] .* tx[:,:,Nq,:]
-      @test sJ[ind,6,:] .* ny[ind,6,:] ≈  J[:,:,Nq,:] .* ty[:,:,Nq,:]
-      @test sJ[ind,6,:] .* nz[ind,6,:] ≈  J[:,:,Nq,:] .* tz[:,:,Nq,:]
+             [ J[Nq,:,:,:] .* ξx[Nq,:,:,:],  J[Nq,:,:,:] .* ξy[Nq,:,:,:],
+               J[Nq,:,:,:] .* ξz[Nq,:,:,:]])
+      @test sJ[ind,3,:] .* nx[ind,3,:] ≈ -J[:, 1,:,:] .* ηx[:, 1,:,:]
+      @test sJ[ind,3,:] .* ny[ind,3,:] ≈ -J[:, 1,:,:] .* ηy[:, 1,:,:]
+      @test sJ[ind,3,:] .* nz[ind,3,:] ≈ -J[:, 1,:,:] .* ηz[:, 1,:,:]
+      @test sJ[ind,4,:] .* nx[ind,4,:] ≈  J[:,Nq,:,:] .* ηx[:,Nq,:,:]
+      @test sJ[ind,4,:] .* ny[ind,4,:] ≈  J[:,Nq,:,:] .* ηy[:,Nq,:,:]
+      @test sJ[ind,4,:] .* nz[ind,4,:] ≈  J[:,Nq,:,:] .* ηz[:,Nq,:,:]
+      @test sJ[ind,5,:] .* nx[ind,5,:] ≈ -J[:,:, 1,:] .* ζx[:,:, 1,:]
+      @test sJ[ind,5,:] .* ny[ind,5,:] ≈ -J[:,:, 1,:] .* ζy[:,:, 1,:]
+      @test sJ[ind,5,:] .* nz[ind,5,:] ≈ -J[:,:, 1,:] .* ζz[:,:, 1,:]
+      @test sJ[ind,6,:] .* nx[ind,6,:] ≈  J[:,:,Nq,:] .* ζx[:,:,Nq,:]
+      @test sJ[ind,6,:] .* ny[ind,6,:] ≈  J[:,:,Nq,:] .* ζy[:,:,Nq,:]
+      @test sJ[ind,6,:] .* nz[ind,6,:] ≈  J[:,:,Nq,:] .* ζz[:,:,Nq,:]
     end
   end
   #}}}
@@ -777,30 +777,30 @@ end
                       zeros(T, Nq, Nq, Nq))
 
       J  = @view vgeo[:,:,:,VGEO3D.J ,:]
-      rx = @view vgeo[:,:,:,VGEO3D.rx,:]
-      ry = @view vgeo[:,:,:,VGEO3D.ry,:]
-      rz = @view vgeo[:,:,:,VGEO3D.rz,:]
-      sx = @view vgeo[:,:,:,VGEO3D.sx,:]
-      sy = @view vgeo[:,:,:,VGEO3D.sy,:]
-      sz = @view vgeo[:,:,:,VGEO3D.sz,:]
-      tx = @view vgeo[:,:,:,VGEO3D.tx,:]
-      ty = @view vgeo[:,:,:,VGEO3D.ty,:]
-      tz = @view vgeo[:,:,:,VGEO3D.tz,:]
+      ξx = @view vgeo[:,:,:,VGEO3D.ξx,:]
+      ξy = @view vgeo[:,:,:,VGEO3D.ξy,:]
+      ξz = @view vgeo[:,:,:,VGEO3D.ξz,:]
+      ηx = @view vgeo[:,:,:,VGEO3D.ηx,:]
+      ηy = @view vgeo[:,:,:,VGEO3D.ηy,:]
+      ηz = @view vgeo[:,:,:,VGEO3D.ηz,:]
+      ζx = @view vgeo[:,:,:,VGEO3D.ζx,:]
+      ζy = @view vgeo[:,:,:,VGEO3D.ζy,:]
+      ζz = @view vgeo[:,:,:,VGEO3D.ζz,:]
 
       e = 1
       for m = 1:Nq
         for n = 1:Nq
-          Cx[:, n, m] += D * (J[:, n, m, e] .* rx[:, n, m, e])
-          Cx[n, :, m] += D * (J[n, :, m, e] .* sx[n, :, m, e])
-          Cx[n, m, :] += D * (J[n, m, :, e] .* tx[n, m, :, e])
+          Cx[:, n, m] += D * (J[:, n, m, e] .* ξx[:, n, m, e])
+          Cx[n, :, m] += D * (J[n, :, m, e] .* ηx[n, :, m, e])
+          Cx[n, m, :] += D * (J[n, m, :, e] .* ζx[n, m, :, e])
 
-          Cy[:, n, m] += D * (J[:, n, m, e] .* rx[:, n, m, e])
-          Cy[n, :, m] += D * (J[n, :, m, e] .* sx[n, :, m, e])
-          Cy[n, m, :] += D * (J[n, m, :, e] .* tx[n, m, :, e])
+          Cy[:, n, m] += D * (J[:, n, m, e] .* ξx[:, n, m, e])
+          Cy[n, :, m] += D * (J[n, :, m, e] .* ηx[n, :, m, e])
+          Cy[n, m, :] += D * (J[n, m, :, e] .* ζx[n, m, :, e])
 
-          Cz[:, n, m] += D * (J[:, n, m, e] .* rx[:, n, m, e])
-          Cz[n, :, m] += D * (J[n, :, m, e] .* sx[n, :, m, e])
-          Cz[n, m, :] += D * (J[n, m, :, e] .* tx[n, m, :, e])
+          Cz[:, n, m] += D * (J[:, n, m, e] .* ξx[:, n, m, e])
+          Cz[n, :, m] += D * (J[n, :, m, e] .* ηx[n, :, m, e])
+          Cz[n, m, :] += D * (J[n, m, :, e] .* ζx[n, m, :, e])
         end
       end
       @test maximum(abs.(Cx)) ≤ 1000 * eps(T)


### PR DESCRIPTION
I have updated the surface metric storage to match the `vmap` storage. I also change `r`, `s`, and `t` in the named tuple to be `ξ`, `η`, and `ζ`. This fixes #26