### PR TITLE
const DFloat in shallow_water.jl

### DIFF
--- a/examples/shallow_water.jl
+++ b/examples/shallow_water.jl
@@ -46,13 +46,14 @@
 #
 #--------------------------------Markdown Language Header-----------------------
 
+const DFloat = Float64 #Number Type
+
 # ### Define Input Parameters:
 # N is polynomial order and
 # brickN(Ne) generates a brick-grid with Ne elements in each direction
 N = 1 #polynomial order
 #brickN = (10) #1D brickmesh
 brickN = (100, 100) #2D brickmesh
-DFloat = Float64 #Number Type
 tend = DFloat(0.005) #Final Time
 δnl = 1.0 #switch to turn on/off nonlinear equations
 gravity = 10.0 #gravity


### PR DESCRIPTION
DFloat being a global was bad in a lot of places.

(second run timing, single-thread Julia not runmpi)

Before
```
 22.408246 seconds (134.51 M allocations: 8.473 GiB, 5.35% gc time) 
```
After
```
 15.890028 seconds (97.70 M allocations: 7.774 GiB, 6.57% gc time)
```