### PR TITLE
+ using CuArrays & Sys.iswindows for MPI finalize

### DIFF
--- a/examples/1d_kernels/LDG1d.jl
+++ b/examples/1d_kernels/LDG1d.jl
@@ -55,6 +55,7 @@ using Printf: @sprintf
 const HAVE_CUDA = try
     using CUDAnative
     using CUDAdrv
+    using CuArrays
     true
 catch
     false
@@ -863,7 +864,9 @@ function main()
     DFloat = Float64
 
     MPI.Initialized() || MPI.Init()
-    MPI.finalize_atexit()
+    if !Sys.iswindows()
+        MPI.finalize_atexit()
+    end
 
     mpicomm = MPI.COMM_WORLD
     mpirank = MPI.Comm_rank(mpicomm)

--- a/examples/1d_kernels/burger1d.jl
+++ b/examples/1d_kernels/burger1d.jl
@@ -75,6 +75,7 @@ using Printf: @sprintf
 const HAVE_CUDA = try
     using CUDAnative
     using CUDAdrv
+    using CuArrays
     true
 catch
     false
@@ -923,7 +924,9 @@ function main()
     DFloat = Float64
 
     MPI.Initialized() || MPI.Init()
-    MPI.finalize_atexit()
+    if !Sys.iswindows()
+        MPI.finalize_atexit()
+    end
 
     mpicomm = MPI.COMM_WORLD
     mpirank = MPI.Comm_rank(mpicomm)

--- a/examples/1d_kernels/swe1d.jl
+++ b/examples/1d_kernels/swe1d.jl
@@ -48,6 +48,7 @@ using Printf: @sprintf
 const HAVE_CUDA = try
     using CUDAnative
     using CUDAdrv
+    using CuArrays
     true
 catch
     false
@@ -993,7 +994,9 @@ function main()
     DFloat = Float64
 
     MPI.Initialized() || MPI.Init()
-    MPI.finalize_atexit()
+    if !Sys.iswindows()
+        MPI.finalize_atexit()
+    end
 
     mpicomm = MPI.COMM_WORLD
     mpirank = MPI.Comm_rank(mpicomm)


### PR DESCRIPTION
The 1D kernels depend on CuArrays, but do not
specify using `CuArrays` in the file, so they fail
to run.

Also, the MPI.finalize_atexit() is not supported
on Windows, and must be used conditionally. A
Sys.iswindows() was used to conditionally use
MPI.finalize_atexit().

With this PR, the 1D examples run without error.